### PR TITLE
Revert VTK::hdf5 workaround + improve error management on missing module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,7 @@ paraview_plugin_scan(
 
 foreach (module IN LISTS required_modules)
   if (NOT TARGET "${module}")
-    message("Missing required module: ${module}")
-    return ()
+    message(SEND_ERROR "Missing required module: ${module}")
   endif ()
 endforeach ()
 

--- a/src/Reader/vtk.module
+++ b/src/Reader/vtk.module
@@ -12,4 +12,4 @@ DEPENDS
 PRIVATE_DEPENDS
   VTK::vtksys
   VTK::mpi
-  VTK::vtkhdf5
+  VTK::hdf5


### PR DESCRIPTION
Better to not spread the workaround that is likely going to be fixed with next release of VTK (and consequently ParaView), since it is already fixed on `VTK@master`.